### PR TITLE
Implement two-step watch valuation flow

### DIFF
--- a/wp-watch-valuation.php
+++ b/wp-watch-valuation.php
@@ -42,35 +42,49 @@ document.addEventListener('DOMContentLoaded',function(){
   hidden.id   = 'wpwv_valuation_preview';
   form.appendChild(hidden);
 
-  form.addEventListener('submit', function(e){
-    if(form.dataset.wpwvAllowSubmit === '1'){
-      return;
+  function showPreview(){
+    if(form.dataset.wpwvPreviewShown === '1') return;
+    var valuation = '$8,500 – $10,500';
+    container.innerHTML = ''
+      + '<div class="wpwv-preview" style="font-size:16px;margin-bottom:8px;">Estimated valuation for your watch: ' + valuation + '</div>'
+      + '<div style="margin-top:4px;font-size:14px;color:#333;">To connect with one of our valuation experts, please <a href="#" id="wpwv-submit-link" style="color:#0073aa;text-decoration:underline;">click here</a>.</div>';
+    var h = document.getElementById('wpwv_valuation_preview');
+    if(h){ h.value = valuation; }
+    if(submitBtn){ submitBtn.disabled = true; }
+    form.dataset.wpwvPreviewShown = '1';
+    var link = container.querySelector('#wpwv-submit-link');
+    if(link){
+      link.addEventListener('click', function(ev){
+        ev.preventDefault();
+        form.dataset.wpwvAllowSubmit = '1';
+        if(submitBtn){ submitBtn.disabled = false; }
+        form.submit();
+      });
     }
+  }
+
+  // Make the original submit button act as a preview trigger only
+  if(submitBtn){
+    submitBtn.setAttribute('type','button');
+    submitBtn.addEventListener('click', function(){
+      if(!form.checkValidity()){
+        form.reportValidity();
+        return;
+      }
+      showPreview();
+    });
+  }
+
+  // Block any form submission (e.g., Enter key) until the link allows it
+  form.addEventListener('submit', function(e){
+    if(form.dataset.wpwvAllowSubmit === '1') return;
     e.preventDefault();
     if(!form.dataset.wpwvPreviewShown){
       if(!form.checkValidity()){
         form.reportValidity();
         return;
       }
-      var valuation = '$8,500 – $10,500';
-      container.innerHTML = ''
-        + '<div class="wpwv-preview" style="font-size:16px;margin-bottom:8px;">Estimated valuation for your watch: ' + valuation + '</div>'
-        + '<div style="margin-top:4px;font-size:14px;color:#333;">To connect with one of our valuation experts, please <a href="#" id="wpwv-submit-link" style="color:#0073aa;text-decoration:underline;">click here</a>.</div>';
-      var h = document.getElementById('wpwv_valuation_preview');
-      if(h){ h.value = valuation; }
-      if(submitBtn){
-        submitBtn.disabled = true;
-      }
-      form.dataset.wpwvPreviewShown = '1';
-      var link = container.querySelector('#wpwv-submit-link');
-      if(link){
-        link.addEventListener('click', function(ev){
-          ev.preventDefault();
-          form.dataset.wpwvAllowSubmit = '1';
-          if(submitBtn){ submitBtn.disabled = false; }
-          form.submit();
-        });
-      }
+      showPreview();
     }
   });
 });

--- a/wp-watch-valuation.php
+++ b/wp-watch-valuation.php
@@ -1,0 +1,239 @@
+<?php
+/*
+Plugin Name: WP Watch Valuation
+Description: Two-step watch valuation (preview, then submit) for WPForms
+Version: 1.2.2
+Author: Your Name
+*/
+
+if (!defined('ABSPATH')) exit;
+
+define('WPWV_FORM_ID', 765);
+
+// === Frontend two-step flow (inline JS) ===
+add_action('wp_enqueue_scripts', function () {
+	if (is_admin()) return;
+
+	$ajax_url = admin_url('admin-ajax.php');
+	$nonce    = wp_create_nonce('wpwv');
+	$form_id  = WPWV_FORM_ID;
+
+	$js = <<<JS
+(function(){
+document.addEventListener('DOMContentLoaded',function(){
+  var form = document.getElementById('wpforms-form-{$form_id}');
+  if(!form) return;
+
+  var submitBtn = form.querySelector('#wpforms-submit-{$form_id}');
+
+  var container = document.createElement('div');
+  container.id = 'wpwv-valuation-container';
+  container.style.margin = '12px 0';
+  var submitWrap = form.querySelector('.wpforms-submit-container');
+  if(submitWrap && submitWrap.parentNode){
+    submitWrap.parentNode.insertBefore(container, submitWrap);
+  } else {
+    form.appendChild(container);
+  }
+
+  var hidden = document.createElement('input');
+  hidden.type = 'hidden';
+  hidden.name = 'wpwv_valuation_preview';
+  hidden.id   = 'wpwv_valuation_preview';
+  form.appendChild(hidden);
+
+  form.addEventListener('submit', function(e){
+    if(form.dataset.wpwvAllowSubmit === '1'){
+      return;
+    }
+    e.preventDefault();
+    if(!form.dataset.wpwvPreviewShown){
+      if(!form.checkValidity()){
+        form.reportValidity();
+        return;
+      }
+      var valuation = '$8,500 – $10,500';
+      container.innerHTML = ''
+        + '<div class="wpwv-preview" style="font-size:16px;margin-bottom:8px;">Estimated valuation for your watch: ' + valuation + '</div>'
+        + '<div style="margin-top:4px;font-size:14px;color:#333;">To connect with one of our valuation experts, please <a href="#" id="wpwv-submit-link" style="color:#0073aa;text-decoration:underline;">click here</a>.</div>';
+      var h = document.getElementById('wpwv_valuation_preview');
+      if(h){ h.value = valuation; }
+      if(submitBtn){
+        submitBtn.disabled = true;
+      }
+      form.dataset.wpwvPreviewShown = '1';
+      var link = container.querySelector('#wpwv-submit-link');
+      if(link){
+        link.addEventListener('click', function(ev){
+          ev.preventDefault();
+          form.dataset.wpwvAllowSubmit = '1';
+          if(submitBtn){ submitBtn.disabled = false; }
+          form.submit();
+        });
+      }
+    }
+  });
+});
+})();
+JS;
+
+	wp_register_script('wpwv-inline', false, [], '1.2.2', true);
+	wp_enqueue_script('wpwv-inline');
+	wp_add_inline_script('wpwv-inline', $js);
+});
+
+// === AJAX: Preview valuation without creating entry (kept for backward compatibility; not used by new flow) ===
+add_action('wp_ajax_nopriv_wp_watch_valuation_preview', 'wpwv_ajax_preview');
+add_action('wp_ajax_wp_watch_valuation_preview', 'wpwv_ajax_preview');
+function wpwv_ajax_preview() {
+	check_ajax_referer('wpwv', 'nonce');
+
+	$raw = isset($_POST['fields']) ? wp_unslash($_POST['fields']) : '';
+	$data = json_decode($raw, true);
+	if (!is_array($data)) {
+		wp_send_json_error(['message' => 'Invalid payload']);
+	}
+
+	$get = function($id) use ($data) {
+		if (!isset($data[$id])) return '';
+		$val = $data[$id];
+		if (is_array($val)) {
+			$flat = array_map('sanitize_text_field', $val);
+			return implode(', ', array_filter($flat));
+		}
+		return sanitize_text_field((string) $val);
+	};
+
+	$normalize = function($v) {
+		$v = trim((string) $v);
+		return ($v === 'Select' || $v === '--- Select Choice ---') ? '' : $v;
+	};
+
+	$brand     = $normalize($get('1'));
+	$model     = $get('2');
+	$reference = $get('12');
+	$year      = $normalize($get('13'));
+	$box       = $get('14');
+	$papers    = $get('15');
+	$age       = $normalize($get('16'));
+	$condition = $normalize($get('4'));
+	$source    = $normalize($get('18'));
+	$series    = '';
+
+	$prompt = "
+	Estimate the market value of this watch based on Chrono24 data:
+	Brand: {$brand}
+	Model: {$model}
+	Series: {$series}
+	Reference Number: {$reference}
+	Purchase Year: {$year}
+	Box: {$box}
+	Papers: {$papers}
+	Age: {$age}
+	Condition (1-10): {$condition}
+	Return only the approximate resale value in price range (e.g., \$10,500 – \$12,000). Do not include explanations, descriptions, references, or any other text.";
+
+	$valuation = wpwv_call_perplexity($prompt);
+	wp_send_json_success(['valuation' => $valuation ?: 'No valuation found']);
+}
+
+// === Final submit: store valuation and show in confirmation ===
+add_action('wpforms_process_complete', 'wpwv_wpforms_process_complete', 10, 4);
+function wpwv_wpforms_process_complete($fields, $entry, $form_data, $entry_id) {
+	if (empty($form_data['id']) || absint($form_data['id']) !== WPWV_FORM_ID) {
+		return;
+	}
+
+	$valuation = '';
+	if (isset($_POST['wpwv_valuation_preview'])) {
+		$valuation = sanitize_text_field(wp_unslash($_POST['wpwv_valuation_preview']));
+	}
+
+	if ($valuation === '') {
+		$get_value = function($id) use ($fields) {
+			if (!isset($fields[$id])) return '';
+			$val = $fields[$id]['value'];
+			if (is_array($val)) {
+				$flat = array_map('sanitize_text_field', $val);
+				return implode(', ', array_filter($flat));
+			}
+			return sanitize_text_field($val);
+		};
+
+		$normalize_select = function($v) {
+			$v = trim((string) $v);
+			return ($v === 'Select' || $v === '--- Select Choice ---') ? '' : $v;
+		};
+
+		$brand     = $normalize_select($get_value(1));
+		$model     = $get_value(2);
+		$reference = $get_value(12);
+		$year      = $normalize_select($get_value(13));
+		$box       = $get_value(14);
+		$papers    = $get_value(15);
+		$age       = $normalize_select($get_value(16));
+		$condition = $normalize_select($get_value(4));
+		$source    = $normalize_select($get_value(18));
+		$series    = '';
+
+		$prompt = "
+		Estimate the market value of this watch based on Chrono24 data:
+		Brand: {$brand}
+		Model: {$model}
+		Series: {$series}
+		Reference Number: {$reference}
+		Purchase Year: {$year}
+		Box: {$box}
+		Papers: {$papers}
+		Age: {$age}
+		Condition (1-10): {$condition}
+		Return only the approximate resale value in price range (e.g., \$10,500 – \$12,000). Do not include explanations, descriptions, references, or any other text.";
+
+		$valuation = wpwv_call_perplexity($prompt);
+	}
+
+	$valuation = $valuation ?: 'No valuation found';
+
+	if (function_exists('wpforms')) {
+		wpforms()->entry_meta->add($entry_id, 'valuation', $valuation);
+	}
+
+	add_filter('wpforms_frontend_confirmation_message', function($message, $form_data_f, $fields_f) use ($valuation) {
+		if (absint($form_data_f['id']) === WPWV_FORM_ID && !empty($valuation)) {
+			return 'Estimated valuation for your watch is ' . esc_html($valuation)
+     . '<br><br><div style="margin-top:8px;font-size:14px;">To get in touch with our valuation expert <a href="/contact-us" style="color:#0073aa;text-decoration:underline;">click here</a>.</div>';
+
+		}
+		return $message;
+	}, 10, 3);
+}
+
+// === Shared: Perplexity API call ===
+function wpwv_call_perplexity($prompt) {
+	$perplexity_api_key = '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'; // Replace with your valid key
+	$api_url = 'https://api.perplexity.ai/chat/completions';
+
+	$response = wp_remote_post($api_url, [
+		'headers' => [
+			'Authorization' => 'Bearer ' . $perplexity_api_key,
+			'Content-Type'  => 'application/json',
+		],
+		'body' => wp_json_encode([
+			'model'       => 'sonar-pro',
+			'messages'    => [
+				['role' => 'system', 'content' => 'You are a watch valuation assistant using Chrono24 market prices.'],
+				['role' => 'user',   'content' => $prompt],
+			],
+			'temperature' => 0.4,
+		]),
+		'timeout' => 60,
+	]);
+
+	if (is_wp_error($response)) {
+		return '';
+	}
+
+	$body = json_decode(wp_remote_retrieve_body($response), true);
+	return $body['choices'][0]['message']['content'] ?? '';
+}
+

--- a/wp-watch-valuation.php
+++ b/wp-watch-valuation.php
@@ -50,14 +50,12 @@ document.addEventListener('DOMContentLoaded',function(){
       + '<div style="margin-top:4px;font-size:14px;color:#333;">To connect with one of our valuation experts, please <a href="#" id="wpwv-submit-link" style="color:#0073aa;text-decoration:underline;">click here</a>.</div>';
     var h = document.getElementById('wpwv_valuation_preview');
     if(h){ h.value = valuation; }
-    if(submitBtn){ submitBtn.disabled = true; }
     form.dataset.wpwvPreviewShown = '1';
     var link = container.querySelector('#wpwv-submit-link');
     if(link){
       link.addEventListener('click', function(ev){
         ev.preventDefault();
         form.dataset.wpwvAllowSubmit = '1';
-        if(submitBtn){ submitBtn.disabled = false; }
         form.submit();
       });
     }
@@ -65,8 +63,11 @@ document.addEventListener('DOMContentLoaded',function(){
 
   // Make the original submit button act as a preview trigger only
   if(submitBtn){
-    submitBtn.setAttribute('type','button');
-    submitBtn.addEventListener('click', function(){
+    // Keep it visually and functionally a button, but block submission
+    submitBtn.addEventListener('click', function(e){
+      if(e && typeof e.preventDefault === 'function') e.preventDefault();
+      if(e && typeof e.stopPropagation === 'function') e.stopPropagation();
+      if(e && typeof e.stopImmediatePropagation === 'function') e.stopImmediatePropagation();
       if(!form.checkValidity()){
         form.reportValidity();
         return;
@@ -87,6 +88,25 @@ document.addEventListener('DOMContentLoaded',function(){
       showPreview();
     }
   });
+
+  // Block Enter key submissions until allowed (except in textarea)
+  form.addEventListener('keydown', function(e){
+    var isEnter = (e.key === 'Enter' || e.keyCode === 13);
+    if(!isEnter) return;
+    var target = e.target || e.srcElement;
+    var isTextArea = target && target.tagName && target.tagName.toLowerCase() === 'textarea';
+    if(isTextArea) return;
+    if(form.dataset.wpwvAllowSubmit === '1') return;
+    e.preventDefault();
+    e.stopPropagation();
+    if(!form.dataset.wpwvPreviewShown){
+      if(!form.checkValidity()){
+        form.reportValidity();
+        return;
+      }
+      showPreview();
+    }
+  }, true);
 });
 })();
 JS;


### PR DESCRIPTION
Implement a two-step watch valuation flow to display a static preview message on initial submit, requiring a "click here" link to trigger the final form submission.

This updates the frontend behavior from a dynamic AJAX-based valuation preview to a predefined static message, ensuring the form only submits after explicit user confirmation via a dedicated link.

---
<a href="https://cursor.com/background-agent?bcId=bc-35f5557c-e77d-45a9-a1ec-3d7bbb5422a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-35f5557c-e77d-45a9-a1ec-3d7bbb5422a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

