### PR TITLE
Update email with valuation and hide button

### DIFF
--- a/wp-watch-valuation/assets/estimate.js
+++ b/wp-watch-valuation/assets/estimate.js
@@ -65,6 +65,20 @@
 
 	function estimate(form, estimateBtn) {
 		var formId = (window.WPWV && WPWV.formId) ? WPWV.formId : getFormIdFromForm(form);
+		// Run validation first: trigger WPForms/client validation and show field-wise errors
+		var originalSubmitBtn = qs(form, '#wpforms-submit-' + formId);
+		if (originalSubmitBtn) {
+			// Intercept the submit to avoid actual submission while letting WPForms show errors
+			var intercept = function(e) { e.preventDefault(); e.stopPropagation(); };
+			form.addEventListener('submit', intercept, true);
+			originalSubmitBtn.click();
+			form.removeEventListener('submit', intercept, true);
+		}
+		// If the form is invalid per HTML5 constraints, show browser errors and stop
+		if (typeof form.checkValidity === 'function' && !form.checkValidity()) {
+			if (typeof form.reportValidity === 'function') form.reportValidity();
+			return;
+		}
 		var brand     = getFieldValue('#wpforms-' + formId + '-field_1');
 		var model     = getFieldValue('#wpforms-' + formId + '-field_2');
 		var reference = getFieldValue('#wpforms-' + formId + '-field_12');

--- a/wp-watch-valuation/assets/estimate.js
+++ b/wp-watch-valuation/assets/estimate.js
@@ -63,7 +63,7 @@
 		}
 	}
 
-	function estimate(form) {
+	function estimate(form, estimateBtn) {
 		var formId = (window.WPWV && WPWV.formId) ? WPWV.formId : getFormIdFromForm(form);
 		var brand     = getFieldValue('#wpforms-' + formId + '-field_1');
 		var model     = getFieldValue('#wpforms-' + formId + '-field_2');
@@ -107,6 +107,18 @@
 				return;
 			}
 			renderEstimate(container, json.data.valuation, submitBtn);
+			// Store valuation in a hidden input so it is included in email submissions
+			var hiddenInput = qs(form, '#wpwv-valuation-input');
+			if (!hiddenInput) {
+				hiddenInput = document.createElement('input');
+				hiddenInput.type = 'hidden';
+				hiddenInput.id = 'wpwv-valuation-input';
+				hiddenInput.name = 'estimated_valuation';
+				form.appendChild(hiddenInput);
+			}
+			hiddenInput.value = json.data && json.data.valuation ? json.data.valuation : '';
+			// Hide the estimate button once we have a valuation
+			hideElement(estimateBtn);
 		})
 		.catch(function() {
 			if (container) container.textContent = 'Unable to calculate estimate right now.';
@@ -161,7 +173,7 @@
 		submitContainer.appendChild(estimateBtn);
 
 		estimateBtn.addEventListener('click', function() {
-			estimate(form);
+			estimate(form, estimateBtn);
 		});
 	}
 

--- a/wp-watch-valuation/assets/estimate.js
+++ b/wp-watch-valuation/assets/estimate.js
@@ -117,6 +117,11 @@
 				form.appendChild(hiddenInput);
 			}
 			hiddenInput.value = json.data && json.data.valuation ? json.data.valuation : '';
+			// Also populate the existing WPForms hidden field so it shows in {all_fields}
+			var wpformsHidden = qs(form, '#wpforms-' + formId + '-field_20');
+			if (wpformsHidden) {
+				wpformsHidden.value = hiddenInput.value;
+			}
 			// Hide the estimate button once we have a valuation
 			hideElement(estimateBtn);
 		})

--- a/wp-watch-valuation/assets/estimate.js
+++ b/wp-watch-valuation/assets/estimate.js
@@ -107,20 +107,11 @@
 				return;
 			}
 			renderEstimate(container, json.data.valuation, submitBtn);
-			// Store valuation in a hidden input so it is included in email submissions
-			var hiddenInput = qs(form, '#wpwv-valuation-input');
-			if (!hiddenInput) {
-				hiddenInput = document.createElement('input');
-				hiddenInput.type = 'hidden';
-				hiddenInput.id = 'wpwv-valuation-input';
-				hiddenInput.name = 'estimated_valuation';
-				form.appendChild(hiddenInput);
-			}
-			hiddenInput.value = json.data && json.data.valuation ? json.data.valuation : '';
-			// Also populate the existing WPForms hidden field so it shows in {all_fields}
+			// Populate the existing WPForms hidden field so it shows in {all_fields}
+			var estimatedValuation = json.data && json.data.valuation ? json.data.valuation : '';
 			var wpformsHidden = qs(form, '#wpforms-' + formId + '-field_20');
 			if (wpformsHidden) {
-				wpformsHidden.value = hiddenInput.value;
+				wpformsHidden.value = estimatedValuation;
 			}
 			// Hide the estimate button once we have a valuation
 			hideElement(estimateBtn);

--- a/wp-watch-valuation/wp-watch-valuation.php
+++ b/wp-watch-valuation/wp-watch-valuation.php
@@ -104,47 +104,5 @@ function wpwv_estimate_valuation() {
 	));
 }
 
-// ================================
-// Email: Append estimated valuation to outgoing message
-// ================================
-add_filter('wpforms_email_message', function($message, $fields, $form_data, $entry_id) {
-	$valuation = isset($_POST['estimated_valuation']) ? sanitize_text_field(wp_unslash($_POST['estimated_valuation'])) : '';
-	if ($valuation !== '') {
-		// Try to detect HTML email and append accordingly
-		if (strip_tags($message) !== $message) {
-			$message .= '<p><strong>Estimated Valuation:</strong> ' . esc_html($valuation) . '</p>';
-		} else {
-			$message .= "\n\nEstimated Valuation: " . $valuation;
-		}
-	}
-	return $message;
-}, 10, 4);
-
-// Ensure the valuation appears in {all_fields} by injecting a synthetic field for emails
-add_filter('wpforms_email_fields', function($fields, $form_data, $emails) {
-	$valuation = isset($_POST['estimated_valuation']) ? sanitize_text_field(wp_unslash($_POST['estimated_valuation'])) : '';
-	if ($valuation !== '') {
-		$fields[999] = array(
-			'id'    => 999,
-			'name'  => 'Estimated Valuation',
-			'value' => $valuation,
-			'type'  => 'text',
-		);
-	}
-	return $fields;
-}, 10, 3);
-
-// Also inject into {all_fields} by adding a synthetic field during processing
-add_filter('wpforms_process_filter', function($fields, $entry, $form_data) {
-	$valuation = isset($_POST['estimated_valuation']) ? sanitize_text_field(wp_unslash($_POST['estimated_valuation'])) : '';
-	if ($valuation !== '') {
-		$fields[999] = array(
-			'id'    => 999,
-			'name'  => 'Estimated Valuation',
-			'value' => $valuation,
-			'type'  => 'text',
-		);
-	}
-	return $fields;
-}, 10, 3);
+// No email filters are needed when using the existing WPForms hidden field (ID 20)
 

--- a/wp-watch-valuation/wp-watch-valuation.php
+++ b/wp-watch-valuation/wp-watch-valuation.php
@@ -104,3 +104,14 @@ function wpwv_estimate_valuation() {
 	));
 }
 
+// ================================
+// Email: Append estimated valuation to outgoing message
+// ================================
+add_filter('wpforms_email_message', function($message, $fields, $form_data, $entry_id) {
+	$valuation = isset($_POST['estimated_valuation']) ? sanitize_text_field(wp_unslash($_POST['estimated_valuation'])) : '';
+	if ($valuation !== '') {
+		$message .= "\n\nEstimated Valuation: " . $valuation;
+	}
+	return $message;
+}, 10, 4);
+


### PR DESCRIPTION
Add estimated valuation to the email body and hide the estimate button after generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1c6e5a5-6e9f-4329-b11d-261a6a84947d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f1c6e5a5-6e9f-4329-b11d-261a6a84947d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

