### PR TITLE
Estimate watch valuation via api

### DIFF
--- a/wp-watch-valuation/assets/estimate.js
+++ b/wp-watch-valuation/assets/estimate.js
@@ -140,17 +140,14 @@
 		}
 		if (!form || !formId) return;
 
-		// Hide any existing Start/Submit buttons
+		// Reference existing Start/Submit buttons
 		var originalSubmit = qs(form, '#wpforms-submit-' + WPWV.formId);
 		var customStartBtn = qs(form, '#wpwv-start-btn');
-		var startBtnClasses = 'wpwv-estimate-btn elementor-button elementor-size-sm wpforms-page-button';
+		var startBtnClasses = 'wpwv-estimate-btn elementor-button elementor-size-sm';
 		if (customStartBtn && customStartBtn.className) {
-			startBtnClasses = customStartBtn.className + ' wpwv-estimate-btn';
+			startBtnClasses = (customStartBtn.className + ' wpwv-estimate-btn').replace(/\bwpforms-page-button\b/g, '').trim();
 		}
-		if (originalSubmit) {
-			originalSubmit.style.display = 'none';
-			originalSubmit.setAttribute('aria-hidden', 'true');
-		}
+		// Keep original submit visible for accessibility
 		hideElement(customStartBtn);
 
 		// Ensure a valuation container exists just above the submit container
@@ -169,6 +166,10 @@
 
 		// Insert Estimate Valuation button (match Start Valuation styles)
 		var estimateBtn = createButton('Estimate Valuation', startBtnClasses);
+		estimateBtn.removeAttribute('disabled');
+		estimateBtn.removeAttribute('aria-hidden');
+		estimateBtn.setAttribute('aria-disabled', 'false');
+		estimateBtn.style.display = '';
 		submitContainer.appendChild(estimateBtn);
 
 		estimateBtn.addEventListener('click', function() {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Ensure the watch valuation message displays correctly on the frontend and the "click here" link functions.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous implementation failed to render the valuation message reliably, particularly with dynamically loaded forms, and the "click here" link was not functional. This update adds a MutationObserver for late-loaded forms, ensures the message container is always created and visible, and makes the link trigger the form submission.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd6eee94-e3be-471f-917b-447bacb926d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd6eee94-e3be-471f-917b-447bacb926d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

